### PR TITLE
Remove erroneous comment in InputFunctions.ino

### DIFF
--- a/examples/MIDI/InputFunctions/InputFunctions.ino
+++ b/examples/MIDI/InputFunctions/InputFunctions.ino
@@ -10,8 +10,6 @@
    Use the Arduino Serial Monitor to view the messages
    as Teensy receives them by USB MIDI
 
-   You must select MIDI from the "Tools > USB Type" menu
-
    This example code is in the public domain.
 */
 


### PR DESCRIPTION
I'm pretty sure the comment specifying that the Teensy needs to be in USB MIDI mode is a copy-and-paste mistake from the Interface_16x16 example. That example hosts a bunch of devices and then forwards the MIDI commands to the Teensy's host, so the Teensy needs to present as a MIDI device to its host. This example just prints out MIDI info, though, so it should just be in standard Serial mode.