### PR TITLE
make parse() in USBHIDParser virtual, so it can be extended

### DIFF
--- a/USBHost_t36.h
+++ b/USBHost_t36.h
@@ -729,7 +729,7 @@ protected:
     bool check_if_using_report_id();
     void parse();
     USBHIDInput * find_driver(uint32_t topusage);
-    void parse(uint16_t type_and_report_id, const uint8_t *data, uint32_t len);
+    virtual void parse(uint16_t type_and_report_id, const uint8_t *data, uint32_t len);
     void init();
 
 


### PR DESCRIPTION
I'm setting up a Teensy to host a Traktor F1 Kontrol midi controller, which is a non-class-compliant MIDI controller. to do this, I need access to the raw HID data. with the existing exposed API, I was unable to figure out how to do this. I attempted to override `hid_input_data()` for this purpose, but the `usage` and `value` parameters didn't give me everything I needed.

by making `parse()` virtual, that allowed me to subclass `USBHIDParser` and override the method to access the raw HID data. this gave me a pretty simple setup to achieve what I was after:

```
class TraktorF1Parser : public USBHIDParser
{
public:
   TraktorF1Parser(USBHost& host) : USBHIDParser(host) { }

   void parse(uint16_t type_and_report_id, const uint8_t* data, uint32_t len) override {
      USBHIDParser::parse(type_and_report_id, data, len);

      /* insert custom parsing code here */
   }
};
```

although, maybe it's possible that there was a way to achieve what I wanted with the existing API, and I couldn't figure it out. if so, let me know!